### PR TITLE
Updated write_file with newline='' to prevent line spaces when writing.

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -109,7 +109,7 @@ def parse_args():
 def write_file(filename, subdomains):
     # saving subdomains results to output file
     print("%s[-] Saving results to file: %s%s%s%s" % (Y, W, R, filename, W))
-    with open(str(filename), 'wt') as f:
+    with open(str(filename), 'wt', newline='') as f:
         for subdomain in subdomains:
             f.write(subdomain + os.linesep)
 


### PR DESCRIPTION
Right now, when the file writer writers a file, it does so with a blank line in between each subdomain. It's an easy fix to implement with newline='' and removes those blank lines. Now, if you need to iterate over the subdomains in the file you don't have to skip the blank lines as they won't exist.
